### PR TITLE
Remove "google3" feature logic

### DIFF
--- a/swank-client_test.lisp
+++ b/swank-client_test.lisp
@@ -40,8 +40,7 @@
 (defvar *server-port* 10000)
 
 (defun unused-port ()
-  #+google3 (port-picker:unused-port)
-  #-google3 (incf *server-port*))
+  (incf *server-port*))
 
 (defun create-swank-server ()
   (let ((port (unused-port)))


### PR DESCRIPTION
This function name has been changed downstream, but let's let downstream be downstream.